### PR TITLE
Fixes a bug making userOptions to be ignored

### DIFF
--- a/lib/bittorrent-sync.js
+++ b/lib/bittorrent-sync.js
@@ -55,11 +55,11 @@ util.inherits(BTSync, events.EventEmitter);
 BTSync.prototype.query = function(method) {
   var
     userOptions =
-      typeof arguments[0] === 'object' ? arguments[0] :
+      typeof arguments[1] === 'object' ? arguments[1] :
       {},
     callback =
+      typeof arguments[2] === 'function' ? arguments[2] :
       typeof arguments[1] === 'function' ? arguments[1] :
-      typeof arguments[0] === 'function' ? arguments[0] :
       null
   ;
   var options = {
@@ -67,7 +67,7 @@ BTSync.prototype.query = function(method) {
       method: method
     }
   };
-  util._extend(options, userOptions);
+  util._extend(options.params, userOptions);
 
   return this.rawQuery(options, callback);
 };


### PR DESCRIPTION
@yannickcr, really impressive how promptly you have developed the API wrapper, given that the API spec was released yesterday

Trying to play with the library, but when passing a user option `{dir: folderPath}`, it is ignored by the library (maybe, I'm doing it wrong?):

``` javascript
        app.btsync.addFolder(
          {dir: folderPath},
          function(err, data) {
            if (err) app.logger.error(err);
            app.logger.info(data);
        });
```

Current change fixes the issue. @yannickcr could you please review and merge?
